### PR TITLE
increment python version so it actually installs

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.linux.nm"
        name="Network-Manager"
-       version="12.0.0"
+       version="12.0.1"
        provider-name="vikjon0">
   <requires>
-    <import addon="xbmc.python" version="2.0"/>
+    <import addon="xbmc.python" version="2.19.0"/>
   </requires>
   <extension point="xbmc.python.script"
              library="default.py" />


### PR DESCRIPTION
This plugin still works, but it depends on an older version of python so it fails to install. Changing the python version to the latest fixes the issue.